### PR TITLE
Action position - not ready for merge, needs discussion

### DIFF
--- a/src/main/java/org/walkmod/javalang/walkers/ChangeLogVisitor.java
+++ b/src/main/java/org/walkmod/javalang/walkers/ChangeLogVisitor.java
@@ -1990,6 +1990,7 @@ public class ChangeLogVisitor extends VoidVisitorAdapter<VisitorContext> {
                 if (sizeArgs != sizeOtherArgs) {
                     applyUpdate(n, aux, theseArgs, otherArgs);
                 }
+                applyUpdate(n, aux, n.getScope(), aux.getScope());
                 applyUpdate(n, aux, n.getTypeArgs(), aux.getTypeArgs());
                 increaseUpdatedNodes(MethodCallExpr.class);
             }

--- a/src/main/java/org/walkmod/javalang/walkers/ChangeLogVisitor.java
+++ b/src/main/java/org/walkmod/javalang/walkers/ChangeLogVisitor.java
@@ -1965,7 +1965,8 @@ public class ChangeLogVisitor extends VoidVisitorAdapter<VisitorContext> {
             setIsUpdated(false);
             Position pos = popPosition();
 
-            position.push(new Position(n.getBeginLine(), n.getBeginColumn()));
+//            position.push(new Position(n.getBeginLine(), n.getBeginColumn()));
+            pushPosition(aux);
             inferASTChanges(n.getScope(), aux.getScope());
             inferASTChanges(n.getTypeArgs(), aux.getTypeArgs());
             List<Expression> theseArgs = n.getArgs();


### PR DESCRIPTION
A wrong position for the action was used and the action was not merged with other actions.

To make the test pass I had to make 2 changes

- push the position of "aux" instead of "n"
- apply updates to "scope"

Is the test wrong?

Otherwise:

At least for reasons of symmetry I suspect that the same kind of problems should be present in
other visit methods.

Why is it ok for other visit methods to push position of "n" instead of "aux"?
I tried to reproduce  a failing test case for another visit method but failed.
I would like to understand the difference.

Why do we need a separate call to apply updates to "scope"? 
Should that be done by an applyUpdate for "n" instead?
Which other visit methods should be checked for the same kind of problem for scope?

 